### PR TITLE
Acronyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.0
+
+### New features
+
+- Add rule to enforce that acronyms are defined on first use. An initial list of exceptions has been agreed by the technical writers
+
 ## v0.1.0
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- Add rule to enforce that acronyms are defined on first use. An initial list of exceptions has been agreed by the technical writers
+- Add rule to enforce that acronyms are defined on first use. GDS technical writers have agreed an initial list of exceptions
 
 ## v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,37 @@
 
 # Linting for technical writing
+
 This package contains rules based on the [GOV.UK Technical Style guide](https://www.gov.uk/guidance/style-guide/technical-content-a-to-z) and is designed to work with the linting tool Vale. You can [find more information about Vale on its website](https://vale.sh/).
 
 Errors raised by the linter will show for each file:
+
 - the line and character number of the issue
 - the severity level of the issue (error, warning, suggestion)
 - a description of the issue
 - the path to the rule that flagged the issue
 
 ## Installing the linter on your local machine
+
 1. Install [Homebrew](https://brew.sh/).
-2. Install [Vale](https://vale.sh/docs/vale-cli/installation/). 
+1. Install [Vale](https://vale.sh/docs/vale-cli/installation/).
 
 ### Adding the tech-docs-linter as a package to your config file
+
 To use the linter (Vale), you must provide a config file which describes where the rules for the linter are located. Confirm that a `.vale.ini` exists at the root of your repo and that the url for the tech-docs-linter zip file is provided through the `Packages` field. Here is a [template](#template-vale-config) config file for reference.
 
 ## Running the linter on your local machine
-By default, Vale must be run from the same directory as this config file, unless the `--config` flag is provide with a path. 
-1. In a terminal window, navigate to your repo
-2. Run `vale sync` to download the latest tech-docs-linter package and unzip this to your `StylesPath` listed in your config file
-3. Run the command `vale .` to lint the entire repo or provide a path to a directory to lint only that directory for example: `vale source/new-starter-guide/*.erb`
 
-## Additional Resources 
+By default, Vale must be run from the same directory as this config file, unless the `--config` flag is provide with a path.
+
+1. In a terminal window, navigate to your repo
+1. Run `vale sync` to download the latest tech-docs-linter package and unzip this to your `StylesPath` listed in your config file
+1. Run the command `vale .` to lint the entire repo or provide a path to a directory to lint only that directory for example: `vale source/new-starter-guide/*.erb`
+
+## Additional Resources
+
 ### Template Vale config
-```
+
+``` yaml
 StylesPath = vale-styles 
 Packages = https://github.com/alphagov/tech-docs-linter/releases/latest/download/tech-writing-style-guide.zip
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Packages = https://github.com/alphagov/tech-docs-linter/releases/latest/download
 erb=md
 MinAlertLevel = error
 [*.{md,org,txt,erb,html}]
+TokenIgnores = (\*{2}(.+)\*{2})
 
 BasedOnStyles = tech-writing-style-guide
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Errors raised by the linter will show for each file:
 - a description of the issue
 - the path to the rule that flagged the issue
 
+If you would like to suggest a change an existing rule, such as adding an acronym to our list of exceptions, please raise this in the [#ask-di-tech-writing-architecture](https://gds.slack.com/archives/C06V5UTTJNP) slack channel, and it will be discussed in our regular forum.
+
 ## Installing the linter on your local machine
 
 1. Install [Homebrew](https://brew.sh/).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ By default, Vale must be run from the same directory as this config file, unless
 1. Run `vale sync` to download the latest tech-docs-linter package and unzip this to your `StylesPath` listed in your config file
 1. Run the command `vale .` to lint the entire repo or provide a path to a directory to lint only that directory for example: `vale source/new-starter-guide/*.erb`
 
+## Releasing an update to the linter
+
+Before releasing a new package make sure the CHANGELOG has been updated.
+To release an update:
+
+- change directory to the styles folder
+- create a zip package of the tech-writing-style-guide folder: `zip -r tech-writing-style-guide.zip tech-writing-style-guide`
+- select **Draft a new release** from the [releases page for the linter](https://github.com/alphagov/tech-docs-linter/releases)
+- upversion the tag and add information about the changes that have been made
+- upload the tech-writing-style-guide package
+
 ## Additional Resources
 
 ### Template Vale config

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ StylesPath = vale-styles
 Packages = https://github.com/alphagov/tech-docs-linter/releases/latest/download/tech-writing-style-guide.zip
 
 # Local Config
+[formats]
+erb=md
 MinAlertLevel = error
 [*.{md,org,txt,erb,html}]
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Errors raised by the linter will show for each file:
 - a description of the issue
 - the path to the rule that flagged the issue
 
-If you would like to suggest a change an existing rule, such as adding an acronym to our list of exceptions, please raise this in the [#ask-di-tech-writing-architecture](https://gds.slack.com/archives/C06V5UTTJNP) slack channel, and it will be discussed in our regular forum.
+If you would like to suggest a change an existing rule, such as adding an acronym to our list of exceptions, please raise this in the [#ask-di-tech-writing-architecture](https://gds.slack.com/archives/C06V5UTTJNP) Slack channel, and it will be discussed in our regular forum.
 
 ## Installing the linter on your local machine
 
@@ -23,7 +23,7 @@ To use the linter (Vale), you must provide a config file which describes where t
 
 ## Running the linter on your local machine
 
-By default, Vale must be run from the same directory as this config file, unless the `--config` flag is provide with a path.
+By default, Vale must be run from the same directory as this config file, unless the `--config` flag is provided with a path.
 
 1. In a terminal window, navigate to your repo
 1. Run `vale sync` to download the latest tech-docs-linter package and unzip this to your `StylesPath` listed in your config file

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,1 +1,0 @@
-zip -r tech-writing-style-guide.zip styles/tech-writing-style-guide

--- a/styles/tech-writing-style-guide/acronyms.yml
+++ b/styles/tech-writing-style-guide/acronyms.yml
@@ -16,6 +16,7 @@ exceptions:
 - NHS
 - DBS
 - NCSC
+- DWP
 
 # GOV.UK One Login specific
 - ADR

--- a/styles/tech-writing-style-guide/acronyms.yml
+++ b/styles/tech-writing-style-guide/acronyms.yml
@@ -16,7 +16,6 @@ exceptions:
 - NHS
 - DBS
 - NCSC
-- DWP
 
 # GOV.UK One Login specific
 - ADR

--- a/styles/tech-writing-style-guide/acronyms.yml
+++ b/styles/tech-writing-style-guide/acronyms.yml
@@ -1,0 +1,73 @@
+extends: conditional
+message: "'%s' must be defined in the first instance"
+level: error
+scope: text
+ignorecase: false
+first: '\b([A-Z]{3,5})\b'
+second: '(?:\b[A-Z|a-z|-]+ )+\(([A-Z]{3,5})\)'
+exceptions:
+# GOV.UK specific
+- GOV
+- GDS
+- CDDO
+- HMRC
+- DVLA
+- DVA
+- NHS
+- DBS
+- NCSC
+
+# GOV.UK One Login specific
+- ADR
+- RFC
+
+# Networking
+- DNS  
+- VPN
+- SSH
+- TLS
+
+# Security
+- RSA
+- GPG
+
+# Accessibility Products
+- JAWS
+- NVDA
+- WAVE
+
+# Internet
+- API
+- REST
+- URL
+- URI
+- HTTP
+- HTTPS
+- HTML
+- CSS
+- SCSS
+- UUID
+- SDK
+
+# Configuration
+- YAML  
+- JSON
+- YYYY
+ 
+# Generic
+- AWS
+- MIT
+- SMS
+- TODO
+- NFC
+- ASCII
+- GDPR
+- ISO
+- SLA
+- UML
+- UTC
+- PDF
+- CPU
+
+# Amazon products 
+- SSM


### PR DESCRIPTION
This pull request adds a rule to require acronyms are spelt out in the first instance to follow the technical style guide. 

The initial list of exceptions was decided by conversation with the DI technical writers and is open for further discussion. 

It is suggested that repos using this rule also use the suggested vale config updates