### PR TITLE
Adjust the Acroynm Regex to exclude Jira tickets and URLs

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 You must enrol with the DCS certificate authority (CA) before you can [raise certificate signing requests (CSRs)](/generate-keys-and-request-certificates/#create-a-certificate-signing-request-csr).
 
-You will need to sign your contract for the DCS pilot before you will be allowed to enrol with the CA. [Contact DCS support](https://dcs-pilot-docs.cloudapps.digital/support/#support) if you need help with your contract. 
+You will need to sign your contract for the DCS pilot before you will be allowed to enrol with the CA. [Contact DCS support](https://dcs-pilot-docs.cloudapps.digital/support/#support) if you need help with your contract.
 
 To help you enrol, the DCS CA needs contact information for certain people within your organisation.
 
@@ -72,3 +72,16 @@ If the DCS CA receives a certificate signing request from someone who is not an 
 Setting up a group inbox is optional but will help make sure you receive your certificates and renewal notices if your requesters or approvers are not available.
 
 If you set up a group inbox, the lead contact should [send an email to idappki@digital.cabinet-office.gov.uk](mailto:idappki@digital.cabinet-office.gov.uk) confirming the group inbox address.
+
+# Ensure your Jira Tickets don't trigger the vale linter
+
+You may have a Jira ticket, let's call it JIA-123.
+If you write this in your doc, it should not error.
+
+# Your URLS don't trigger the vale linter
+
+Hey... we all like a clean URL, but sometimes that's out of our control.
+Atlassian projects allow upcased URLs, like atlassian.net/wiki/spaces/BOOP/
+
+You generally can downcase them, but then you get a redirect, and we prefer canonical URLs.
+So... let's ensure vale doesn't trigger for those

--- a/styles/tech-writing-style-guide/acronyms.yml
+++ b/styles/tech-writing-style-guide/acronyms.yml
@@ -8,9 +8,6 @@ second: '(?:\b[A-Z|a-z|-]+ )+\(([A-Z]{3,5})\)'
 exceptions:
 # Departmental
 - DSIT
-
-# GOV.UK specific
-- GOV
 - GDS
 - CDDO
 - HMRC
@@ -19,6 +16,9 @@ exceptions:
 - NHS
 - DBS
 - NCSC
+
+# GOV.UK specific
+- GOV
 
 # GOV.UK One Login specific
 - ADR

--- a/styles/tech-writing-style-guide/acronyms.yml
+++ b/styles/tech-writing-style-guide/acronyms.yml
@@ -6,6 +6,9 @@ ignorecase: false
 first: '\b([A-Z]{3,5})\b'
 second: '(?:\b[A-Z|a-z|-]+ )+\(([A-Z]{3,5})\)'
 exceptions:
+# Departmental
+- DSIT
+
 # GOV.UK specific
 - GOV
 - GDS

--- a/styles/tech-writing-style-guide/acronyms.yml
+++ b/styles/tech-writing-style-guide/acronyms.yml
@@ -3,8 +3,8 @@ message: "'%s' must be defined in the first instance"
 level: error
 scope: text
 ignorecase: false
-first: '\b([A-Z]{3,5})\b'
-second: '(?:\b[A-Z|a-z|-]+ )+\(([A-Z]{3,5})\)'
+first: '(?<!/)\b([A-Z]{3,5})\b(?!/\b)(?!-\d)'
+second: '(?:\b[A-Za-z-]+ )+\(([A-Z]{3,5})\)'
 exceptions:
 # Departmental
 - DSIT

--- a/styles/tech-writing-style-guide/acronyms.yml
+++ b/styles/tech-writing-style-guide/acronyms.yml
@@ -25,7 +25,7 @@ exceptions:
 - RFC
 
 # Networking
-- DNS  
+- DNS
 - VPN
 - SSH
 - TLS
@@ -53,10 +53,10 @@ exceptions:
 - SDK
 
 # Configuration
-- YAML  
+- YAML
 - JSON
 - YYYY
- 
+
 # Generic
 - AWS
 - MIT
@@ -72,5 +72,5 @@ exceptions:
 - PDF
 - CPU
 
-# Amazon products 
+# Amazon products
 - SSM


### PR DESCRIPTION
## What

- Tidies us the acronym overrides file (whitespace)
- Adds DSIT now we're a part of them (common acronym)
- Adds a test case for some false positives I'm seeing a lot
- Adjusts Regex to remove them

## Why

Snippet from the test case I wrote

```md
# Ensure your Jira Tickets don't trigger the vale linter

You may have a Jira ticket, let's call it JIA-123.
If you write this in your doc, it should not error.

# Your URLS don't trigger the vale linter

Hey... we all like a clean URL, but sometimes that's out of our control.
Atlassian projects allow upcased URLs, like atlassian.net/wiki/spaces/BOOP/

You generally can downcase them, but then you get a redirect, and we prefer canonical URLs.
So... let's ensure vale doesn't trigger for those
```