### PR TITLE
Refactor: Focus on report count and level, not pass and fail

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 #4.9.0
         with:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 #4.9.0
         with:

--- a/config.rb
+++ b/config.rb
@@ -4,36 +4,3 @@ require 'open3'
 require 'json'
 
 GovukTechDocs.configure(self)
-
-after_build do |builder|
-  begin
-    
-    # {stderr.read} #{wait_thr.value.exitstatus}
-    puts("\n\nResults of Vale's style checks:")
-    puts("\nFor each suggestion, the numbers at the start are the line number and character number in the HTML file - not the Markdown file)")
-    stdin, stdout, stderr, wait_thr = Open3.popen3("vale --no-wrap build/")
-    if wait_thr.value.exitstatus == 0 || wait_thr.value.exitstatus == 1
-      vale_results = stdout.read
-      puts(vale_results)
-    else
-      puts(wait_thr.value.exitstatus)
-      puts(stderr)
-    end
-
-    puts("\n\nResults of HTMLProofer's checks:")
-    HTMLProofer.check_directory(config[:build_dir],
-      { :assume_extension => true,
-        :disable_external => false,
-        :allow_hash_href => true,
-        :empty_alt_ignore => true,
-        :extensions => [],
-        :log_level => ':warn',
-      }
-    ).run
-
-      
-  rescue RuntimeError => e
-    abort e.to_s
-  end
-  
-end

--- a/features/step_definitions/shared.rb
+++ b/features/step_definitions/shared.rb
@@ -44,7 +44,7 @@ end
 # ]
 #}
 
-Then('the number of errors in the linter report should be {float}') do |number_of_errors|
+Then('the number of messages in the linter report should be {float}') do |number_of_errors|
   if number_of_errors < 1
     expect(vale_result.json.size).to be 0
   end
@@ -59,7 +59,12 @@ Then('the number of errors in the linter report should be {float}') do |number_o
 
 end
 
+Then('the error level should be {string}') do | error_level|
+  expect(@vale_result_json[0]["Severity"]).to eq(error_level)
+end
+
 Then('the error should include {string}') do |error_message|
   expect(@vale_result_json[0]).to have_key("Message")
   expect(@vale_result_json[0]["Message"]).to include(error_message)
 end
+

--- a/features/style_guide/acronyms.feature
+++ b/features/style_guide/acronyms.feature
@@ -1,5 +1,4 @@
-Feature: Acronyms are defined in technical documentation
-    No-one likes likes to not know what "an acronym" means
+Feature: Acronyms that are not on the exceptions list need to be defined in full the first time they are used.  If the linter finds any that fail this rule they should be added to the final output report
 
     Scenario: A page has been created with a single unknown acronym that has not been defined in full
         Given a page contains "a single uncommon undefined" acronym

--- a/features/style_guide/acronyms.feature
+++ b/features/style_guide/acronyms.feature
@@ -4,24 +4,24 @@ Feature: Acronyms are defined in technical documentation
     Scenario: A page has been created with a single unknown acronym that has not been defined in full
         Given a page contains "a single uncommon undefined" acronym
         When the linter runs against the page with the "acronyms" rule
-        Then the linter should "fail"
-        And the number of errors in the linter report should be 1
+        Then the number of errors in the linter report should be 1
+        And the error level should be "error"
         And the error should include "must be defined in the first instance"
 
     Scenario: A page has been created with a single unknown acronym that has been defined in full
         Given a page contains "a single uncommon defined" acronym
         When the linter runs against the page with the "acronyms" rule
-        Then the linter should "pass"
+        Then the number of errors in the linter report should be 0
 
     Scenario: A page has been created with a widley known acronym that has been defined in full
         Given a page contains "a single common defined" acronym
         When the linter runs against the page with the "acronyms" rule
-        Then the linter should "pass"
+        Then the number of errors in the linter report should be 0
 
     Scenario: A page has been created with a widley known acronym, and not defined unnecessarily
         Given a page contains "a single common undefined" acronym
         When the linter runs against the page with the "acronyms" rule
-        Then the linter should "pass"
+        Then the number of errors in the linter report should be 0
 
 #add scenarios for multiple things on a page, some defined some not
 
@@ -29,12 +29,12 @@ Feature: Acronyms are defined in technical documentation
         Given a page contains "<types_of_acronyms>" acronyms
         And "<amount_of_acronyms>" of the acronyms have been defined
         When the linter runs against the page with the "acronyms" rule
-        Then the linter should "<linter_result>"
-        And the number of errors in the linter report should be <error_count>
+        Then the number of errors in the linter report should be <error_count>
+
         Examples:
-            | types_of_acronyms | amount_of_acronyms | linter_result | error_count |
-            | multiple uncommon | all                | pass          | 0           |
-            | multiple uncommon | none defined       | fail          | 3           |
-            | multiple common   | none defined       | pass          | 0           |
-            | 3 common 3 uncommon  | none defined       | fail          | 3           |
-            | 3 common 4 uncommon  | half defined       | fail          | 2           |
+            | types_of_acronyms | amount_of_acronyms |  error_count |
+            | multiple uncommon | all                | 0           |
+            | multiple uncommon | none defined       | 3           |
+            | multiple common   | none defined       | 0           |
+            | 3 common 3 uncommon  | none defined       |  3           |
+            | 3 common 4 uncommon  | half defined       | 2           |

--- a/features/style_guide/acronyms.feature
+++ b/features/style_guide/acronyms.feature
@@ -3,24 +3,24 @@ Feature: Acronyms that are not on the exceptions list need to be defined in full
     Scenario: A page has been created with a single unknown acronym that has not been defined in full
         Given a page contains "a single uncommon undefined" acronym
         When the linter runs against the page with the "acronyms" rule
-        Then the number of errors in the linter report should be 1
+        Then the number of messages in the linter report should be 1
         And the error level should be "error"
         And the error should include "must be defined in the first instance"
 
     Scenario: A page has been created with a single unknown acronym that has been defined in full
         Given a page contains "a single uncommon defined" acronym
         When the linter runs against the page with the "acronyms" rule
-        Then the number of errors in the linter report should be 0
+        Then the number of messages in the linter report should be 0
 
     Scenario: A page has been created with a widley known acronym that has been defined in full
         Given a page contains "a single common defined" acronym
         When the linter runs against the page with the "acronyms" rule
-        Then the number of errors in the linter report should be 0
+        Then the number of messages in the linter report should be 0
 
     Scenario: A page has been created with a widley known acronym, and not defined unnecessarily
         Given a page contains "a single common undefined" acronym
         When the linter runs against the page with the "acronyms" rule
-        Then the number of errors in the linter report should be 0
+        Then the number of messages in the linter report should be 0
 
 #add scenarios for multiple things on a page, some defined some not
 
@@ -28,7 +28,7 @@ Feature: Acronyms that are not on the exceptions list need to be defined in full
         Given a page contains "<types_of_acronyms>" acronyms
         And "<amount_of_acronyms>" of the acronyms have been defined
         When the linter runs against the page with the "acronyms" rule
-        Then the number of errors in the linter report should be <error_count>
+        Then the number of messages in the linter report should be <error_count>
 
         Examples:
             | types_of_acronyms | amount_of_acronyms |  error_count |

--- a/features/style_guide/misspellings.feature
+++ b/features/style_guide/misspellings.feature
@@ -3,14 +3,13 @@ Feature: Sometimes there are different ways to spell something.  The linter shou
   Scenario: A page exists with a single commonly misspelled word
     Given a page contains "a single" misspelling
     When the linter runs against the page with the "common-misspellings" rule
-    Then the linter should "fail"
-    And the number of errors in the linter report should be 1
+    Then the number of messages in the linter report should be 1
     And the error should include "The GOV.UK style guide recommends"
 
 
   Scenario: A page exists with the correct spelling of One Login
     Given a page contains "no" misspelling
     When the linter runs against the page with the "common-misspellings" rule
-    Then the linter should "pass"
+    Then the number of messages in the linter report should be 0
 
 


### PR DESCRIPTION
## Proposed changes

### What changed

Refactoring of the test steps to remove "pass" or "fail" step, and instead concentrate on the report count and the severity level of the warning

## Related issue or tracking reference

You should have an open GitHub issue that this PR will fix.  

This currently doens't have an issue as it's a minor refactor

## Related feature files

updates to aconyms.feature and common-misspellings.feature (to be used for future rules also)

## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [x] you have added, updated or removed any scenarios affected by the change
- [x] GitHub actions all pass
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed