### PR TITLE
Make 'commit' a word to avoid unless

### DIFF
--- a/styles/tech-writing-style-guide/words-to-avoid-unless.yml
+++ b/styles/tech-writing-style-guide/words-to-avoid-unless.yml
@@ -8,6 +8,7 @@ swap:
   # main style guide
   agenda: use ‘plan’ (unless it’s for a meeting)
   combat: use ‘solve’, ‘fix’ or something more specific (unless military)
+  commit: unless you a talking about version control use ‘plan to [fulfill your commitment]’
   deploy: use ‘use’ or if putting something somewhere use ‘build’, ‘create’ or ‘put into place’ (unless it’s military or software)
   foster: use ‘encourage’ or ‘help’ (unless it’s children)
   impact: use ‘have an effect on’ or ‘influence’ (unless talking about a collision)

--- a/styles/tech-writing-style-guide/words-to-avoid.yml
+++ b/styles/tech-writing-style-guide/words-to-avoid.yml
@@ -8,7 +8,7 @@ swap:
   # main style guide
   advance: use ‘improve’ or something more specific
   collaborate: use ‘work with’
-  '(commit | pledge)': use ‘plan to [fulfill your commitment]’, or ‘we’re going to x’ where ‘x’ is a specific verb
+  pledge: use ‘we’re going to x’ where ‘x’ is a specific verb
   counter: use ‘prevent’ or try to rephrase a solution to a problem
   deliver: use ‘make’, ‘create’, ‘provide’ or a more specific term (pizzas, post and services are delivered - not abstract concepts like improvements)
   dialogue: use ‘spoke to’ or ‘discussion’


### PR DESCRIPTION
## Proposed changes
- move commit to words to avoid unless
### What changed

From feedback on the linter, technical audiences use the word `commit` in the context of version control.  So this change moves it to a suggestion rather than an error

## Related issue or tracking reference

You should have an open GitHub issue that this PR will fix.  

- Fixes #57 
- Relates to #53 


## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [x] you have added, updated or removed any scenarios affected by the change
- [x] GitHub actions all pass
- [x] you have linked this PR to an issue (or explained why none exists)
- [x] you have updated documentation if needed